### PR TITLE
Remove deprecated Slack community link from docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -76,11 +76,6 @@
           "icon": "book-open-cover"
         },
         {
-          "anchor": "Community",
-          "href": "https://mintlify.com/community",
-          "icon": "slack"
-        },
-        {
           "anchor": "Blog",
           "href": "https://mintlify.com/blog",
           "icon": "newspaper"


### PR DESCRIPTION
Removes the Slack community link from the navigation menu as the workspace has been discontinued.